### PR TITLE
Manually import the script of jacoco configuration for both Android library module & android app module

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.application'
-apply from: "${rootDir}/gradle/test.gradle"
-
+apply plugin: 'jacoco'
+//Enable RobolectricTestRunner  https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/issues/18#issuecomment-576630461
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
 android {
 
     testOptions {

--- a/library_android/build.gradle
+++ b/library_android/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
-apply from: "${rootDir}/gradle/test.gradle"
+apply plugin: 'jacoco'
+//Enable RobolectricTestRunner  https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/issues/18#issuecomment-576630461
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
 android {
 
     compileSdkVersion projectVersion.compileSdk


### PR DESCRIPTION
This pull request is introduced to surface another minor different behavior that I had noticed, which is for `'com.android.application'`, it is required to add the extra configuration. However, for `apply plugin: 'com.android.library'`, it is not required.

```
//Enable RobolectricTestRunner  https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin/issues/18#issuecomment-576630461
tasks.withType(Test) {
    jacoco.includeNoLocationClasses = true
}
```